### PR TITLE
feat: expose LoadBalancer backend via Route

### DIFF
--- a/iac/route.yaml
+++ b/iac/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-route
+  namespace: sergidomingo-dev
+  labels: {}
+spec:
+  to:
+    kind: Service
+    name: mds-service
+  tls: null
+  path: /hello
+  port:
+    targetPort: http

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,3 +22,4 @@ cat ./iac/deployment.yaml
 ./bin/oc login --token=$1 --server=$2
 ./bin/oc apply -f ./iac/deployment.yaml
 ./bin/oc apply -f ./iac/service.yaml
+./bin/oc apply -f ./iac/route.yaml


### PR DESCRIPTION
A Route is an OpenShift object similar to an Ingress, which is able to expose a LoadBalancer to the outside world using a URL.

I used the OpenShift UI to generate the YAML file, and the settings are the exact same that I've used to expose a test URL that we used with valid results.

So, in short, this should work fine.